### PR TITLE
feat: parse only specific extension tag

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -32,6 +32,7 @@ const (
 	overridesFileFlag    = "overridesFile"
 	parseGoListFlag      = "parseGoList"
 	quietFlag            = "quiet"
+	parseExtensionFlag   = "parseExtension"
 )
 
 var initFlags = []cli.Flag{
@@ -123,6 +124,11 @@ var initFlags = []cli.Flag{
 		Value: true,
 		Usage: "Parse dependency via 'go list'",
 	},
+	&cli.StringFlag{
+		Name:  parseExtensionFlag,
+		Value: "",
+		Usage: "Parse only those operations that match given extension",
+	},
 }
 
 func initAction(ctx *cli.Context) error {
@@ -146,6 +152,7 @@ func initAction(ctx *cli.Context) error {
 	return gen.New().Build(&gen.Config{
 		SearchDir:           ctx.String(searchDirFlag),
 		Excludes:            ctx.String(excludeFlag),
+		ParseExtension:      ctx.String(parseExtensionFlag),
 		MainAPIFile:         ctx.String(generalInfoFlag),
 		PropNamingStrategy:  strategy,
 		OutputDir:           ctx.String(outputFlag),

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -65,6 +65,9 @@ type Config struct {
 	// excludes dirs and files in SearchDir,comma separated
 	Excludes string
 
+	// outputs only those operations with "x-public: true" extension
+	ParseExtension string
+
 	// OutputDir represents the output directory for all the generated files
 	OutputDir string
 
@@ -149,6 +152,7 @@ func (g *Gen) Build(config *Config) error {
 	p := swag.New(swag.SetMarkdownFileDirectory(config.MarkdownFilesDir),
 		swag.SetDebugger(config.Debugger),
 		swag.SetExcludedDirsAndFiles(config.Excludes),
+		swag.SetParseExtension(config.ParseExtension),
 		swag.SetCodeExamplesDirectory(config.CodeExampleFilesDir),
 		swag.SetStrict(config.Strict),
 		swag.SetOverrides(overrides),


### PR DESCRIPTION
**Describe the PR**
Enable parsing (output) of specific operations which have specific tag (extension).

**Relation issue**
https://github.com/swaggo/swag/issues/661

**Additional context**

**Usage**
Add comment tag like
`// @x-public true`

on cli use `swag init --parseExtension public`

result will be that only those operations with `@x-public true` will be saved to the swagger definition
